### PR TITLE
Replace Date Marshalling with recursive msgpack

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
     spec.extensions  = ["ext/bootsnap/extconf.rb"]
   end
 
-  spec.add_dependency("msgpack", "~> 1.2")
+  spec.add_dependency("msgpack", "~> 1.5")
 end

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -79,7 +79,7 @@ struct bs_cache_key {
 STATIC_ASSERT(sizeof(struct bs_cache_key) == KEY_SIZE);
 
 /* Effectively a schema version. Bumping invalidates all previous caches */
-static const uint32_t bootsnap_cache_version = 7;
+static const uint32_t bootsnap_cache_version = 8;
 
 /* Invalidates cache when switching ruby version, platform or ABI */
 static uint64_t base_ruby_version_digest = 0;

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -89,16 +89,58 @@ module Bootsnap
             unpacker: MessagePack::Time::Unpacker,
           )
 
-          marshal_fallback = {
+          factory.register_type(
+            0x01,
+            Date,
+            packer: lambda { |date, packer|
+              packer.write(date.year)
+              packer.write(date.month)
+              packer.write(date.day)
+            },
+            unpacker: lambda { |unpacker|
+              ::Date.new(unpacker.read, unpacker.read, unpacker.read)
+            },
+            recursive: true,
+          )
+
+          factory.register_type(
+            0x02,
+            Regexp,
             packer: ->(value) { Marshal.dump(value) },
             unpacker: ->(payload) { Marshal.load(payload) },
-          }
-          {
-            Date => 0x01,
-            Regexp => 0x02,
-          }.each do |type, code|
-            factory.register_type(code, type, marshal_fallback)
-          end
+          )
+
+          factory.register_type(
+            0x03,
+            DateTime,
+            packer: lambda { |dt, packer|
+              packer.write(dt.year)
+              packer.write(dt.month)
+              packer.write(dt.day)
+              packer.write(dt.hour)
+              packer.write(dt.minute)
+
+              sec = dt.sec + dt.sec_fraction
+              packer.write(sec.numerator)
+              packer.write(sec.denominator)
+
+              offset = dt.offset
+              packer.write(offset.numerator)
+              packer.write(offset.denominator)
+            },
+            unpacker: lambda { |unpacker|
+              ::DateTime.new(
+                unpacker.read, # year
+                unpacker.read, # month
+                unpacker.read, # day
+                unpacker.read, # hour
+                unpacker.read, # minute
+                Rational(unpacker.read, unpacker.read), # sec fraction
+                Rational(unpacker.read, unpacker.read), # offset fraction
+              )
+            },
+            recursive: true,
+          )
 
           self.msgpack_factory = factory
 

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -142,6 +142,15 @@ module Bootsnap
             recursive: true,
           )
 
+          require "msgpack/bigint"
+          factory.register_type(
+            0x04,
+            Integer,
+            packer: MessagePack::Bigint.method(:to_msgpack_ext),
+            unpacker: MessagePack::Bigint.method(:from_msgpack_ext),
+            oversized_integer_extension: true,
+          )
+
           self.msgpack_factory = factory
 
           self.supported_options = []

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -47,14 +47,6 @@ module Bootsnap
           SUPPORTED_INTERNAL_ENCODINGS.include?(Encoding.default_internal)
         end
 
-        module EncodingAwareSymbols
-          extend self
-
-          def unpack(payload)
-            (+payload).force_encoding(Encoding::UTF_8).to_sym
-          end
-        end
-
         def init!
           require "yaml"
           require "msgpack"
@@ -86,27 +78,26 @@ module Bootsnap
             0x00,
             Symbol,
             packer: :to_msgpack_ext,
-            unpacker: EncodingAwareSymbols.method(:unpack).to_proc,
+            unpacker: :from_msgpack_ext,
+            optimized_symbol_parsing: true,
           )
 
-          if defined? MessagePack::Timestamp
-            factory.register_type(
-              MessagePack::Timestamp::TYPE, # or just -1
-              Time,
-              packer: MessagePack::Time::Packer,
-              unpacker: MessagePack::Time::Unpacker,
-            )
+          factory.register_type(
+            MessagePack::Timestamp::TYPE, # or just -1
+            Time,
+            packer: MessagePack::Time::Packer,
+            unpacker: MessagePack::Time::Unpacker,
+          )
 
-            marshal_fallback = {
-              packer: ->(value) { Marshal.dump(value) },
-              unpacker: ->(payload) { Marshal.load(payload) },
-            }
-            {
-              Date => 0x01,
-              Regexp => 0x02,
-            }.each do |type, code|
-              factory.register_type(code, type, marshal_fallback)
-            end
+          marshal_fallback = {
+            packer: ->(value) { Marshal.dump(value) },
+            unpacker: ->(payload) { Marshal.load(payload) },
+          }
+          {
+            Date => 0x01,
+            Regexp => 0x02,
+          }.each do |type, code|
+            factory.register_type(code, type, marshal_fallback)
           end
 
           self.msgpack_factory = factory
@@ -116,7 +107,7 @@ module Bootsnap
           if params.include?([:key, :symbolize_names])
             supported_options << :symbolize_names
           end
-          if params.include?([:key, :freeze]) && factory.load(factory.dump("yaml"), freeze: true).frozen?
+          if params.include?([:key, :freeze])
             supported_options << :freeze
           end
           supported_options.freeze

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -257,6 +257,18 @@ class CompileCacheYAMLTest < Minitest::Test
       Help.set_file("a.yml", ::YAML.dump(foo: /bar/), 100)
       assert_equal({foo: /bar/}, FakeYaml.unsafe_load_file("a.yml"))
     end
+
+    def test_unsafe_load_file_supports_date
+      today = Date.today
+      Help.set_file("a.yml", ::YAML.dump(today), 100)
+      2.times { assert_equal(today, FakeYaml.unsafe_load_file("a.yml")) }
+    end
+
+    def test_unsafe_load_file_supports_datetime
+      dt = DateTime.now
+      Help.set_file("a.yml", ::YAML.dump(dt), 100)
+      2.times { assert_equal(dt, FakeYaml.unsafe_load_file("a.yml")) }
+    end
   end
 
   def test_no_read_permission

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -269,6 +269,12 @@ class CompileCacheYAMLTest < Minitest::Test
       Help.set_file("a.yml", ::YAML.dump(dt), 100)
       2.times { assert_equal(dt, FakeYaml.unsafe_load_file("a.yml")) }
     end
+
+    def test_unsafe_load_file_supports_bigint
+      bigint = 2**150
+      Help.set_file("a.yml", ::YAML.dump(bigint), 100)
+      2.times { assert_equal(bigint, FakeYaml.unsafe_load_file("a.yml")) }
+    end
   end
 
   def test_no_read_permission

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -53,7 +53,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
     key = cache_key_for_file(FILE)
     hash = Help.fnv1a_64(RUBY_DESCRIPTION)
-    hash = Help.fnv1a_64_iter(hash, [7].pack("L"))
+    hash = Help.fnv1a_64_iter(hash, [8].pack("L"))
     hash = Help.fnv1a_64_iter(hash, [Zlib.crc32(RubyVM::InstructionSequence.compile_option.inspect)].pack("L"))
     assert_equal([hash].pack("Q"), key[R[:ruby_version_digest]])
   end


### PR DESCRIPTION
It's more compact, faster, and doesn't use Marshal.

```ruby
# frozen_string_literal: true

require "date"
require "msgpack"
require "benchmark/ips"

def codec(**opts)
  f = MessagePack::Factory.new
  f.register_type(0x01, Date, **opts)
  f
end

CODECS = {
  "current (Marshal)" => codec(
    packer: ->(d) { Marshal.dump(d) },
    unpacker: ->(p) { Marshal.load(p) },
  ),

  "3 ints" => codec(
    packer: ->(d, pk) { pk.write(d.year); pk.write(d.month); pk.write(d.day) },
    unpacker: ->(u) { Date.new(u.read, u.read, u.read) },
    recursive: true,
  ),

  # similar to paquito, but uses unpack1/shifting to avoid array allocation
  "bitpack" => codec(
    packer: ->(d) { [(d.year << 9) | (d.month << 5) | d.day].pack("l<") },
    unpacker: ->(p) { v = p.unpack1("l<"); Date.new(v >> 9, (v >> 5) & 0xF, v & 0x1F) },
  ),
}

DATE = Date.new(2024, 6, 15)

CODECS.each { |n, f| raise n unless f.load(f.dump(DATE)) == DATE }

Benchmark.ips do |x|
  CODECS.each do |n, f|
    b = f.dump(DATE)
    puts " %-22s %2d bytes  %s" % [n, b.bytesize, b.bytes.map { |x| "%02X" % x }.join(" ")]

    b = f.dump(10.times.map { DATE })
    x.report(n) { f.load(b) }
  end
  x.compare!
end
```

```
$ ruby bench.rb
 current (Marshal)      36 bytes  C7 21 01 04 08 55 3A 09 44 61 74 65 5B 0B 69 00 69 03 3D 8B 25 69 00 69 00 69 00 66 0C 32 32 39 39 31 36 31
 3 ints                  8 bytes  C7 05 01 CD 07 E8 06 0F
 bitpack                 6 bytes  D6 01 CF D0 0F 00
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [x86_64-linux]
Warming up --------------------------------------
   current (Marshal)     2.616k i/100ms
              3 ints    16.045k i/100ms
             bitpack    11.230k i/100ms
Calculating -------------------------------------
   current (Marshal)     27.840k (± 3.9%) i/s   (35.92 μs/i) -    141.264k in   5.074188s
              3 ints    157.179k (± 2.4%) i/s    (6.36 μs/i) -    786.205k in   5.001970s
             bitpack    110.688k (± 2.5%) i/s    (9.03 μs/i) -    561.500k in   5.072816s

Comparison:
           3 ints:   157179.1 i/s
          bitpack:   110688.0 i/s - 1.42x  slower
current (Marshal):    27839.7 i/s - 5.65x  slower
```

I included an approach similar to Paquito ("bitpack") in the benchmark, but it uses unpack1 and shifting to avoid allocating an array when unpacking (Paquito's implementation uses unpack so it allocates). Like Paquito's implementation, it only uses 6 bytes but is slower than the "3 ints" approach.

I went with "3 ints" because its the fastest at unpacking, the implementation is very simple, and it only uses an extra 2 bytes per Date. Compared to the 36 bytes currently used by Marshal, the extra 2 seems negligible.

One advantage of Marshal.dump is that it automatically handles subclasses of Date, so I also added a "simple" DateTime type mirroring Paquito.