### PR TITLE
Convert the path argument in the frame that reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Fix `CompileCache::Native.fetch` and `.precompile` reading a non-`String` path argument (e.g. a `Pathname`)
+  with `RSTRING_PTR`. Regression from 1.24.0.
+
 # 1.24.6
 
 * Fix detection of Ruby bug #22023 on some patch versions of Ruby 3.4, and properly apply the workaround.

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -395,12 +395,14 @@ get_ruby_version_digest(void)
  * be stored.
  *
  * The path will look something like: <cachedir>/12/34567890abcdef
+ *
+ * `path_v` must already have been through FilePathValue(): the callers read it
+ * with RSTRING_PTR() too, so the conversion has to happen in the frame that
+ * owns the variable.
  */
 static void
 bs_cache_path(VALUE cachedir_v, VALUE namespace_v, VALUE path_v, char (* cache_path)[MAX_CACHEPATH_SIZE])
 {
-  FilePathValue(path_v);
-
   Check_Type(cachedir_v, T_STRING);
   Check_Type(path_v, T_STRING);
 
@@ -492,6 +494,8 @@ static void bs_cache_key_digest(struct bs_cache_key *key,
 static VALUE
 bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE namespace_v, VALUE path_v, VALUE handler, VALUE args)
 {
+  FilePathValue(path_v);
+
   char cache_path[MAX_CACHEPATH_SIZE];
 
   /* generate cache path to cache_path */
@@ -508,6 +512,8 @@ bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE namespace_v, VALUE path_v, VALUE
 static VALUE
 bs_rb_precompile(VALUE self, VALUE cachedir_v, VALUE namespace_v, VALUE path_v, VALUE handler)
 {
+  FilePathValue(path_v);
+
   char cache_path[MAX_CACHEPATH_SIZE];
   /* generate cache path to cache_path */
   bs_cache_path(cachedir_v, namespace_v, path_v, &cache_path);

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 require "tempfile"
 require "tmpdir"
 require "fileutils"
+require "pathname"
 
 class CompileCacheKeyFormatTest < Minitest::Test
   FILE = File.expand_path(__FILE__)
@@ -88,6 +89,31 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
     actual = Bootsnap::CompileCache::Native.fetch(cache_dir, nil, target, TestHandler, nil)
     assert_equal("NEATO #{target.upcase}", actual)
+  end
+
+  def test_fetch_pathname
+    target = Help.set_file("a.rb", "foo = 1")
+
+    cache_dir = File.join(@tmp_dir, "compile_cache")
+    actual = Bootsnap::CompileCache::Native.fetch(cache_dir, nil, Pathname.new(target), TestHandler, nil)
+    assert_equal("NEATO #{target.upcase}", actual)
+
+    # Same cache entry as the String form: the path is converted before it is
+    # hashed and before it is read back with RSTRING_PTR.
+    Bootsnap::CompileCache::Native.fetch(cache_dir, nil, target, TestHandler, nil)
+    entries = Dir["#{cache_dir}/**/*"].select { |f| File.file?(f) }
+    assert_equal(1, entries.size)
+  end
+
+  def test_precompile_pathname
+    target = Help.set_file("a.rb", "foo = 1")
+
+    cache_dir = File.join(@tmp_dir, "compile_cache")
+    assert(Bootsnap::CompileCache::Native.precompile(cache_dir, nil, Pathname.new(target), TestHandler))
+
+    entries = Dir["#{cache_dir}/**/*"].select { |f| File.file?(f) }
+    assert_equal(1, entries.size)
+    assert_equal("neato #{target}", File.read(entries.first).b[CACHE_KEY_SIZE..])
   end
 
   def test_revalidation


### PR DESCRIPTION
`bs_cache_path` takes `path_v` **by value** and calls `FilePathValue` on its own copy. `bs_rb_fetch` and `bs_rb_precompile` then call `RSTRING_PTR(path_v)` on *their* copy, which is still the unconverted argument:

```c
static void
bs_cache_path(VALUE cachedir_v, VALUE namespace_v, VALUE path_v, char (* cache_path)[MAX_CACHEPATH_SIZE])
{
  FilePathValue(path_v);        /* converts the callee's copy */
  Check_Type(path_v, T_STRING); /* checks the callee's copy */
  ...
}

static VALUE
bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE namespace_v, VALUE path_v, VALUE handler, VALUE args)
{
  char cache_path[MAX_CACHEPATH_SIZE];
  bs_cache_path(cachedir_v, namespace_v, path_v, &cache_path);
  return bs_fetch(RSTRING_PTR(path_v), path_v, cache_path, handler, args);
                /*             ^ caller's copy, never converted */
}
```

Pass a `Pathname` and `RSTRING_PTR` reads a `T_OBJECT` as if it were an `RString`. The `Check_Type(path_v, T_STRING)` in `bs_cache_path` reads like it covers the callers, but it only ever sees the callee's copy.

## Regression

`FilePathValue` was added to `bs_rb_fetch` in 68b166c0 (2018) precisely so `YAML.load_file` could be handed a non-String — the frame that converted was the frame that read. 320ca021 ("Allow to substitute the Ruby compiler", first released in v1.24.0) moved it down into `bs_cache_path`, but `RSTRING_PTR(path_v)` stayed behind in the callers.

Bisected on ruby 4.0.6 (arm64-darwin23) with a temporary probe on `rb_type(path_v)` and `RSTRING_LEN(path_v)` immediately before the `RSTRING_PTR` in `bs_rb_fetch`, calling `Native.fetch(cachedir, nil, Pathname.new(file), handler, nil)` on each tag:

| version | `rb_type(path_v)` | `RSTRING_LEN(path_v)` | result |
| --- | --- | --- | --- |
| v1.23.0 | 5 (`T_STRING`) | 82 | returns the value |
| v1.24.0 | 1 (`T_OBJECT`) | 4875499440 | `TypeError` |
| v1.24.1 | 1 (`T_OBJECT`) | 4837488560 | `TypeError` |
| v1.24.6 | 1 (`T_OBJECT`) | 4838405920 | `TypeError` |

v1.18.4 and v1.18.6 have the conversion in the entry points by inspection; I couldn't build them against ruby 4.0.6 to run the same probe.

The nonsense length is the `Pathname`'s object slot read through `RSTRING(str)->len`. `RSTRING_PTR` misreads the same slot: `RSTRING_NOEMBED` is clear on a `T_OBJECT`, so it takes the embedded branch and returns a pointer 16 bytes into the object, which is what `open()` then gets as a NUL-terminated path. The `TypeError` you actually observe is raised much later — `fail_errno:` does `rb_str_concat(..., exception_message)` with `exception_message == path_v`, i.e. the `Pathname` — by which point the out-of-bounds read and the `open()` on a wild pointer have already happened.

## Severity

Latent, and I don't want to oversell it. Every in-gem caller passes a String: `compile_cache/iseq.rb` passes `path.to_s`, `compile_cache/yaml.rb` passes `File.realpath(path)` or `path.to_s`. Hitting it takes an out-of-gem caller of the public `Bootsnap::CompileCache::Native.fetch` / `.precompile` passing a `Pathname` or anything else `to_path`-able. That's type-triggered, not attacker-controlled. It's worth fixing because the API accepts those values by design — that's why `FilePathValue` is there at all — and because the surviving `Check_Type` gives a reader false assurance.

## Fix

Move `FilePathValue` back to the two cfunc entry points, i.e. revert that part of 320ca021. `bs_cache_path` keeps `Check_Type(path_v, T_STRING)`, which now genuinely asserts a precondition rather than establishing one the caller doesn't get.

The other candidate was `bs_cache_path(..., VALUE *path_v, ...)` with write-back, which is the general fix for this defect class. I went with the smaller diff: there are exactly two callers, both are cfunc entry points, and this restores the shape that shipped unchanged from 1.18 through 1.23. Happy to switch to the pointer form if you'd rather have the callee own it.

## Tests

`test_fetch_pathname` and `test_precompile_pathname` in `test/compile_cache_key_format_test.rb`. On this branch with the C change reverted they fail:

```
  1) Failure:
CompileCacheKeyFormatTest#test_precompile_pathname [test/compile_cache_key_format_test.rb:112]:
Expected false to be truthy.

  2) Error:
CompileCacheKeyFormatTest#test_fetch_pathname:
TypeError: no implicit conversion of Pathname into String
    test/compile_cache_key_format_test.rb:98:in 'Bootsnap::CompileCache::Native.fetch'
```

With it, the full suite on ruby 4.0.6 / arm64-darwin23:

```
157 runs, 340 assertions, 0 failures, 0 errors, 0 skips
```
