### PR TITLE
Ignore YJIT status in the compile cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+* Don't invalidate the compile cache when YJIT is toggled. YJIT is a runtime JIT and doesn't change the
+  serialized instruction sequences that are cached, but enabling it (via `--yjit`, `RUBYOPT`, or
+  `RubyVM::YJIT.enable`) adds a ` +YJIT` marker to `RUBY_DESCRIPTION` (` +YJIT <token>` on `YJIT_SUPPORT`
+  builds), which is part of the cache key. This previously discarded the entire compile cache whenever YJIT
+  was enabled at runtime but not at precompile time (or vice versa). The marker is now stripped before hashing.
+
 * Fix `CompileCache::Native.fetch` and `.precompile` reading a non-`String` path argument (e.g. a `Pathname`)
   with `RSTRING_PTR`. Regression from 1.24.0.
 

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -384,7 +384,7 @@ bs_compile_option_crc32_set(VALUE self, VALUE crc32_v)
 static uint64_t
 get_ruby_version_digest(void)
 {
-  uint64_t hash = fnv1a_64_str(rb_const_get(rb_cObject, rb_intern("RUBY_DESCRIPTION")));
+  uint64_t hash = fnv1a_64_str(rb_const_get(rb_mBootsnap, rb_intern("RUBY_CACHE_KEY")));
   hash = fnv1a_64_iter(hash, (unsigned char *)&bootsnap_cache_version, sizeof(bootsnap_cache_version));
   return hash;
 }

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -6,6 +6,9 @@ require_relative "bootsnap/bundler"
 module Bootsnap
   InvalidConfiguration = Class.new(StandardError)
 
+  # JITs shouldn't change the cache key as they have no impact on iseq generation
+  RUBY_CACHE_KEY = RUBY_DESCRIPTION.gsub(/\s\+\wJIT/, "").freeze
+
   class << self
     attr_reader :cache_dir, :logger
 

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -53,7 +53,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
     Bootsnap::CompileCache::ISeq.compile_option_updated
 
     key = cache_key_for_file(FILE)
-    hash = Help.fnv1a_64(RUBY_DESCRIPTION)
+    hash = Help.fnv1a_64(Bootsnap::RUBY_CACHE_KEY)
     hash = Help.fnv1a_64_iter(hash, [8].pack("L"))
     hash = Help.fnv1a_64_iter(hash, [Zlib.crc32(RubyVM::InstructionSequence.compile_option.inspect)].pack("L"))
     assert_equal([hash].pack("Q"), key[R[:ruby_version_digest]])

--- a/test/integration/yjit_compile_cache_test.rb
+++ b/test/integration/yjit_compile_cache_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "tmpdir"
+
+module Bootsnap
+  # YJIT is a runtime JIT and does not change the serialized instruction
+  # sequences the compile cache stores, so toggling it must not invalidate the
+  # cache. Enabling YJIT at interpreter startup adds a " +YJIT" marker to
+  # RUBY_DESCRIPTION, which is part of the cache key, so this can only be
+  # exercised across separate processes.
+  class YJITCompileCacheTest < Minitest::Test
+    include CompileCacheISeqHelper
+
+    def test_cache_is_reused_when_yjit_is_toggled
+      skip("MRI only") unless RUBY_ENGINE == "ruby"
+      skip("YJIT unavailable") unless defined?(RubyVM::YJIT) && RubyVM::YJIT.respond_to?(:enable)
+
+      Dir.mktmpdir("bootsnap-yjit") do |dir|
+        cache_dir = File.join(dir, "cache")
+        source = File.join(dir, "a.rb")
+        File.write(source, "def a; a = 1; end\n")
+
+        # The first run populates the cache; the second reads it back with
+        # `--yjit`. The two runs must actually observe different YJIT states for
+        # this to exercise the toggle. If YJIT can't be turned off here (e.g. a
+        # future Ruby that enables it by default), there is no toggle to test,
+        # so skip rather than fail.
+        populate = run_subprocess(cache_dir, source, yjit: false)
+        reuse = run_subprocess(cache_dir, source, yjit: true)
+
+        if populate[:yjit] == reuse[:yjit]
+          skip("Cannot exercise a YJIT toggle in this environment (YJIT=#{reuse[:yjit]})")
+        end
+
+        assert_equal("miss", populate[:event], populate[:output])
+
+        # Reusing the cache across the YJIT toggle must be a hit, not stale:
+        # YJIT changes RUBY_DESCRIPTION but not the serialized ISeq.
+        assert_equal("hit", reuse[:event], reuse[:output])
+      end
+    end
+
+    private
+
+    # Boots the locally-built bootsnap in a subprocess (so YJIT can be toggled
+    # at interpreter startup), loads `source` through the ISeq compile cache in
+    # `cache_dir`, and reports whether YJIT was enabled and which cache event
+    # (`hit`/`miss`/`stale`) occurred.
+    SUBPROCESS_SCRIPT = <<~'RUBY'
+      require "bootsnap"
+      Bootsnap::CompileCache.setup(cache_dir: ENV.fetch("CACHE_DIR"), iseq: true, yaml: false)
+      event = nil
+      Bootsnap.instrumentation = ->(e, _path) { event = e }
+      load(ENV.fetch("TARGET"))
+      puts("YJIT:#{defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?}")
+      puts("EVENT:#{event}")
+    RUBY
+
+    def run_subprocess(cache_dir, source, yjit:)
+      env = {
+        "CACHE_DIR" => cache_dir,
+        "TARGET" => source,
+        "RUBYOPT" => yjit ? "--yjit" : "",
+      }
+      lib = File.expand_path("../../../lib", __FILE__)
+      output, status = Open3.capture2e(env, RbConfig.ruby, "-I", lib, "-e", SUBPROCESS_SCRIPT)
+      assert_predicate(status, :success?, output)
+
+      {
+        yjit: output[/YJIT:(\w+)/, 1],
+        event: output[/EVENT:(\w+)/, 1],
+        output: output,
+      }
+    end
+  end
+end


### PR DESCRIPTION
The compile cache key includes a digest of `RUBY_DESCRIPTION`, which changes when YJIT is enabled (it gains a ` +YJIT` marker). Because YJIT is a runtime JIT that does not affect the serialized instruction sequences that are cached, this caused the entire compile cache to be treated as stale and recompiled whenever YJIT was enabled at runtime (via `--yjit`, `RUBYOPT`, or `RubyVM::YJIT.enable`) but not at precompile time, or vice versa. A binary ISeq compiled with YJIT off loads and runs correctly with YJIT on and vice versa, so this was purely a false- positive invalidation.

Strip the YJIT marker from `RUBY_DESCRIPTION` before hashing it so the digest is stable regardless of YJIT. On release builds the marker is ` +YJIT`; builds with `YJIT_SUPPORT` defined append a token such as ` +YJIT dev` (see Ruby's `YJIT_DESCRIPTION`), so an optional trailing ` <token>` is also consumed. Other markers such as ` +PRISM` are left intact.

The added subprocess test populates the cache with YJIT disabled and then loads the same file with `RUBYOPT=--yjit`, asserting the result is a cache hit rather than stale.

Closes https://github.com/rails/bootsnap/issues/562