### PR TITLE
Save and restore errinfo around instrumentation_method

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -318,7 +318,13 @@ static inline void
 bs_instrumentation(VALUE event, VALUE path)
 {
     if (RB_UNLIKELY(instrumentation_enabled)) {
+       // If the funcall raises and rescues an error we will lose the errinfo
+       // that exists now so we save it before and restore it after.
+       VALUE saved_errinfo = rb_errinfo();
        rb_funcall(rb_mBootsnap, instrumentation_method, 2, event, path);
+       // If the ruby code in instrumentation_method raised we won't reach this point.
+       // If it didn't raise it _might_ have rescued so we should restore errinfo.
+       rb_set_errinfo(saved_errinfo);
     }
 }
 

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -267,4 +267,46 @@ class CompileCacheTest < Minitest::Test
 
     assert_equal [[:stale, "a.rb"]], calls
   end
+
+  def test_instrumentation_does_not_swallow_handler_exception
+    file_path = Help.set_file("a.rb", "a = a = 3", 100)
+    load(file_path)
+
+    Bootsnap.instrumentation = lambda { |_event, _path|
+      begin
+        raise "instrumentation internal error"
+      rescue StandardError
+      end
+    }
+
+    klass = Class.new(StandardError)
+    Bootsnap::CompileCache::ISeq::DEFAULT.expects(:storage_to_output).raises(klass, "oops")
+
+    assert_raises(klass) { load(file_path) }
+  end
+
+  def test_instrumentation_callback_raise_overrides_handler_exception
+    file_path = Help.set_file("a.rb", "a = a = 3", 100)
+    load(file_path)
+
+    instrumentation_error = Class.new(StandardError)
+    Bootsnap.instrumentation = lambda { |_event, _path|
+      raise instrumentation_error, "instrumentation failure"
+    }
+
+    handler_error = Class.new(StandardError)
+    Bootsnap::CompileCache::ISeq::DEFAULT.expects(:storage_to_output).raises(handler_error, "handler failure")
+
+    # When the instrumentation callback raises a new exception (not rescued),
+    # the raise escapes via rb_funcall's longjmp — bypassing both
+    # rb_set_errinfo and rb_jump_tag. The callback's exception propagates
+    # directly to the caller. rb_set_errinfo is never reached, so the fix
+    # cannot overwrite the callback's exception with the saved handler one.
+    # The last exception raised wins, but the original handler exception is
+    # preserved as .cause (Ruby chains ec->errinfo as cause automatically),
+    # so neither is lost.
+    raised = assert_raises(instrumentation_error) { load(file_path) }
+    assert_kind_of(handler_error, raised.cause)
+    assert_equal("handler failure", raised.cause.message)
+  end
 end


### PR DESCRIPTION
This fixes a SEGV that occurs when ruby assumes errinfo is an object.
https://bugs.ruby-lang.org/issues/22240