### PR TITLE
Handle `::Coverage` not being stdlib coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Handle top level `Coverage` constant being defined, but without it being the true stdlib `coverage` module.
+
 # 1.25.0
 
 * Improve YAML parsing cache to more efficiently handle `Time`, `Date` and `DateTime`.

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -172,11 +172,11 @@ module Bootsnap
 
         if RUBY_VERSION < "3.1."
           def self.coverage_on?
-            defined?(Coverage) && Coverage.running?
+            defined?(Coverage.running?) && Coverage.running?
           end
         else
           def self.coverage_on?
-            defined?(Coverage) && Coverage.state != :idle
+            defined?(Coverage.state) && Coverage.state != :idle
           end
         end
 


### PR DESCRIPTION
Fix: https://github.com/rails/bootsnap/issues/565